### PR TITLE
Fix navigation permission check

### DIFF
--- a/src/Resources/contao/modules/Mate/NavBarModule.php
+++ b/src/Resources/contao/modules/Mate/NavBarModule.php
@@ -431,6 +431,12 @@ class NavBarModule extends \Module
         if (version_compare(VERSION, '4.12', '<'))
         {
             $groups = array();
+            $user = $security->getUser();
+
+            if ($user instanceof FrontendUser) {
+                $groups = StringUtil::deserialize($user->groups, true);
+            }
+
             $_groups = StringUtil::deserialize($objSubpage->groups);
 
             if (!$objSubpage->protected || BE_USER_LOGGED_IN || (is_array($_groups) && is_array($groups) && count(array_intersect($_groups, $groups))) || $this->showProtected || ($this instanceof ModuleSitemap && $objSubpage->sitemap == 'map_always'))

--- a/src/Resources/contao/modules/Mate/NavBarModule.php
+++ b/src/Resources/contao/modules/Mate/NavBarModule.php
@@ -12,6 +12,7 @@ namespace ContaoThemesNet\MateThemeBundle\Mate;
 
 use Contao\Environment;
 use Contao\FrontendTemplate;
+use Contao\FrontendUser;
 use Contao\ModuleSitemap;
 use Contao\PageModel;
 use Contao\StringUtil;


### PR DESCRIPTION
Currently if you protect a page in Contao 4.9, the navigation module will never show this page, even if the front end user has the correct group. This is because the check currently never actually checks the user's group. It just checks against an empty array.

This PR fixes that by actually loading the user's groups.